### PR TITLE
Support IPv6, Linux, DoH and Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ Log file name:
 update-cloudflare-dns.log
 ```
 
-## Limitations
-
-- Does not support IPv6
-
 ## License
 
 ### MIT License

--- a/update-cloudflare-dns.ps1
+++ b/update-cloudflare-dns.ps1
@@ -1,3 +1,5 @@
+# https://github.com/fire1ce/DDNS-Cloudflare-PowerShell
+
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 ### updateDNS.log file of the last run for debug
@@ -14,7 +16,7 @@ Write-Output "==> $DATE" | Tee-Object $File_LOG -Append
 
 ### Load config file
 Try {
-  . $PSScriptRoot\update-cloudflare-dns_conf.ps1 
+  . $PSScriptRoot\update-cloudflare-dns_conf.ps1
 }
 Catch {
   Write-Output "==> Error! Missing update-cloudflare-dns_conf.ps1 or invalid syntax" | Tee-Object $File_LOG -Append
@@ -22,8 +24,8 @@ Catch {
 }
 
 ### Check validity of "ttl" parameter
-if (( $ttl -lt 120 ) -or ($ttl -gt 7200 ) -and ( $ttl -ne 1 )) {
-  Write-Output 'Error! ttl out of range (120-7200) or not set to 1' | Tee-Object $File_LOG -Append
+if (( $ttl -lt 60 ) -or ($ttl -gt 7200 ) -and ( $ttl -ne 1 )) {
+  Write-Output 'Error! ttl out of range (60) or not set to 1' | Tee-Object $File_LOG -Append
   Exit
 }
 
@@ -35,20 +37,22 @@ if (!([string]$proxied) -or ($proxied.GetType().Name.Trim() -ne "Boolean")) {
 
 
 ### Check validity of "what_ip" parameter
-if ( ($what_ip -ne "external") -and ($what_ip -ne "internal")) {
+if ( ($what_ip -ne "external") -and ($what_ip -ne "internal") ) {
   Write-Output 'Error! Incorrect "what_ip" parameter choose "external" or "internal"' | Tee-Object $File_LOG -Append
   Exit
 }
 
-### Check if set to internal ip and proxy
-if (($what_ip -eq "internal") -and ($proxied)) {
-  Write-Output 'Error! Internal IP cannot be Proxied' | Tee-Object $File_LOG -Append
-  Exit
+### Get External ip from internet
+function Get-Ip-External {
+    param ([bool] $IPv6)
+    if ($IPv6) {
+        return (Invoke-RestMethod -Uri "http://v6.ident.me" -TimeoutSec 10).Trim()
+    } else {
+        return (Invoke-RestMethod -Uri "https://checkip.amazonaws.com" -TimeoutSec 10).Trim()
+    }
 }
-
-### Get External ip from https://checkip.amazonaws.com
 if ($what_ip -eq 'external') {
-  $ip = (Invoke-RestMethod -Uri "https://checkip.amazonaws.com" -TimeoutSec 10).Trim()
+  $ip = Get-Ip-External -IPv6 $IPv6
   if (!([bool]$ip)) {
     Write-Output "Error! Can't get external ip from https://checkip.amazonaws.com" | Tee-Object $File_LOG -Append
     Exit
@@ -57,18 +61,66 @@ if ($what_ip -eq 'external') {
 }
 
 ### Get Internal ip from primary interface
+function Get-Ip-Internal {
+    param ([bool] $IPv6)
+
+    if ($IsLinux) {
+        if ($IPv6) {
+            return ip -6 addr | grep inet6 | awk -F '[ \t]+|/' '{print $3}' | grep -v ^::1 | grep -v ^f | head -1
+        }
+        else {
+            return ip -4 addr | grep inet | awk -F '[ \t]+|/' '{print $3}' | grep -v ^127 | grep -v ^192 | grep -v ^f | head -1
+        }
+    } elseif ($IsWindows) {
+        $InternalIPTestAddress = switch ($IPv6) {
+            $true { "2606:4700::1111" }
+            $false { "1.1.1.1" }
+        }
+        $addr = $((Find-NetRoute -RemoteIPAddress $InternalIPTestAddress).IPAddress|out-string).Trim()
+        if ($addr -eq "127.0.0.1" -or $addr -eq "::1") {
+            return $null
+        }
+        return $addr
+    } elseif ($IsMacOS) {
+        throw "Get-Internal-IpAddress is not implemented for MacOS."
+    }
+}
 if ($what_ip -eq 'internal') {
-  $ip = $((Find-NetRoute -RemoteIPAddress 1.1.1.1).IPAddress|out-string).Trim()
-  if (!([bool]$ip) -or ($ip -eq "127.0.0.1")) {
+  $ip = Get-Ip-Internal -IPv6 $IPv6
+  if (![bool]$ip) {
     Write-Output "==>Error! Can't get internal ip address" | Tee-Object $File_LOG -Append
     Exit
   }
   Write-Output "==> Internal IP is $ip" | Tee-Object $File_LOG -Append
 }
 
+
 ### Get IP address of DNS record from 1.1.1.1 DNS server when proxied is "false"
+function Resolve-DnsName-From-Cloudflare {
+    param ([bool] $DoH, [string] $domain, [bool] $IPv6)
+    $type = switch ($IPv6) {
+        $true { "AAAA" }
+        $false { "A" }
+    }
+    if ($DoH) {
+        $response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential -Uri https://cloudflare-dns.com/dns-query -Body @{
+            name = $domain
+            type = $type
+        } -Headers @{ 'Accept' = 'application/dns-json' }
+        if ($response) {
+            return $response.Answer[0].data
+        }
+        return $null
+    } else {
+        $ip = (Resolve-DnsName -Name $domain -Server 1.1.1.1 -Type $type | Select-Object -First 1)
+        if ($ip) {
+          return $ip.IPAddress.Trim()
+        }
+        return $null
+    }
+}
 if ($proxied -eq $false) {
-  $dns_record_ip = (Resolve-DnsName -Name $dns_record -Server 1.1.1.1 -Type A | Select-Object -First 1).IPAddress.Trim()
+  $dns_record_ip = Resolve-DnsName-From-Cloudflare -DoH $DNS_over_HTTPS -domain $dns_record -IPv6 $IPv6
   if (![bool]$dns_record_ip) {
     Write-Output "Error! Can't resolve the ${dns_record} via 1.1.1.1 DNS server" | Tee-Object $File_LOG -Append
     Exit
@@ -82,8 +134,8 @@ if ($proxied -eq $true) {
     Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
     Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
   }
-  
-  $response = Invoke-RestMethod @dns_record_info
+
+  $response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @dns_record_info
   if ($response.success -ne "True") {
     Write-Output "Error! Can't get dns record info from cloudflare's api" | Tee-Object $File_LOG -Append
   }
@@ -106,7 +158,7 @@ $cloudflare_record_info = @{
   Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
 }
 
-$cloudflare_record_info_resposne = Invoke-RestMethod @cloudflare_record_info
+$cloudflare_record_info_resposne = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @cloudflare_record_info
 if ($cloudflare_record_info_resposne.success -ne "True") {
   Write-Output "Error! Can't get $dns_record record inforamiton from cloudflare API" | Tee-Object $File_LOG -Append
   Exit
@@ -121,7 +173,10 @@ $update_dns_record = @{
   Method  = 'PUT'
   Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
   Body    = @{
-    "type"    = "A"
+    "type"    = switch ($IPv6) {
+        $true { "AAAA" }
+        $false { "A" }
+    }
     "name"    = $dns_record
     "content" = $ip
     "ttl"     = $ttl
@@ -129,7 +184,7 @@ $update_dns_record = @{
   } | ConvertTo-Json
 }
 
-$update_dns_record_response = Invoke-RestMethod @update_dns_record
+$update_dns_record_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @update_dns_record
 if ($update_dns_record_response.success -ne "True") {
   Write-Output "Error! Update Failed" | Tee-Object $File_LOG -Append
   Exit
@@ -148,15 +203,15 @@ if ($notify_me_telegram -eq "yes") {
     Uri    = "https://api.telegram.org/bot$telegram_bot_API_Token/sendMessage?chat_id=$telegram_chat_id&text=$dns_record DNS Record Updated To: $ip"
     Method = 'GET'
   }
-  $telegram_notification_response = Invoke-RestMethod @telegram_notification
+  $telegram_notification_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @telegram_notification
   if ($telegram_notification_response.ok -ne "True") {
     Write-Output "Error! Telegram notification failed" | Tee-Object $File_LOG -Append
     Exit
   }
 }
 
-if ($notify_me_discord -eq "yes") { 
-  $discord_message = "$dns_record DNS Record Updated To: $ip (was $dns_record_ip)" 
+if ($notify_me_discord -eq "yes") {
+  $discord_message = "$dns_record DNS Record Updated To: $ip (was $dns_record_ip)"
   $discord_payload = [PSCustomObject]@{content = $discord_message} | ConvertTo-Json
   $discord_notification = @{
     Uri    = $discord_webhook_URL
@@ -165,7 +220,7 @@ if ($notify_me_discord -eq "yes") {
     Headers = @{ "Content-Type" = "application/json" }
   }
     try {
-      Invoke-RestMethod @discord_notification
+      Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @discord_notification
     } catch {
       Write-Host "==> Discord notification request failed. Here are the details for the exception:" | Tee-Object $File_LOG -Append
       Write-Host "==> Request StatusCode:" $_.Exception.Response.StatusCode.value__  | Tee-Object $File_LOG -Append

--- a/update-cloudflare-dns.ps1
+++ b/update-cloudflare-dns.ps1
@@ -66,7 +66,7 @@ function Get-Ip-Internal {
 
     if ($IsLinux) {
         if ($IPv6) {
-            return ip -6 addr | grep inet6 | awk -F '[ \t]+|/' '{print $3}' | grep -v ^::1 | grep -v ^f | head -1
+            return ip -6 addr | grep inet6 | awk -F '[ \t]+|/' '{print $3}' | grep -v ^::1 | grep -v ^f | sort | head -1
         }
         else {
             return ip -4 addr | grep inet | awk -F '[ \t]+|/' '{print $3}' | grep -v ^127 | grep -v ^192 | grep -v ^f | head -1

--- a/update-cloudflare-dns_conf.ps1
+++ b/update-cloudflare-dns_conf.ps1
@@ -5,6 +5,10 @@
 $what_ip = "internal"
 ## DNS A record to be updated
 $dns_record = "ddns.example.com"
+## Use IPv6
+$IPv6 = $false
+## if use DoH to query the current IP address
+$DNS_over_HTTPS = $false
 ## Cloudflare's Zone ID
 $zoneid = "ChangeMe"
 ## Cloudflare Zone API Token
@@ -13,6 +17,10 @@ $cloudflare_zone_api_token = "ChangeMe"
 $proxied = $false
 ## 120-7200 in seconds or 1 for Auto
 $ttl = 120
+
+## Use proxy when connect to DoH, Cloudflare, Telegram or Discord API
+# $http_proxy = $null
+# $proxy_credential = $null
 
 ## Telegram Notifications yes/no (only sent if DNS is updated)
 $notify_me_telegram = "no"

--- a/update-cloudflare-dns_conf.ps1
+++ b/update-cloudflare-dns_conf.ps1
@@ -15,7 +15,7 @@ $zoneid = "ChangeMe"
 $cloudflare_zone_api_token = "ChangeMe"
 ## Use Cloudflare proxy on dns record true/false
 $proxied = $false
-## 120-7200 in seconds or 1 for Auto
+## 60-7200 in seconds or 1 for Auto
 $ttl = 120
 
 ## Use proxy when connect to DoH, Cloudflare, Telegram or Discord API


### PR DESCRIPTION
- Minimal TTL changed to 60 because Cloudflare supports that.
- Add IPv6 support
- Add Linux support for `internal`
- Add DoH support for getting the current IP of the hostname.

I only tested with the following combination:

- Windows + IPv6 + DoH + Proxy
- Linux + IPv6 + DoH + Proxy

I don't have IPv4 public address so I cannot test that.