### PR TITLE
Support for updating multiple A/AAAA records

### DIFF
--- a/update-cloudflare-dns.ps1
+++ b/update-cloudflare-dns.ps1
@@ -23,19 +23,6 @@ Catch {
   Exit
 }
 
-### Check validity of "ttl" parameter
-if (( $ttl -lt 60 ) -or ($ttl -gt 7200 ) -and ( $ttl -ne 1 )) {
-  Write-Output 'Error! ttl out of range (60) or not set to 1' | Tee-Object $File_LOG -Append
-  Exit
-}
-
-### Check validity of "proxied" parameter
-if (!([string]$proxied) -or ($proxied.GetType().Name.Trim() -ne "Boolean")) {
-  Write-Output 'Error! Incorrect "proxied" parameter choose "$true" or "$false" ' | Tee-Object $File_LOG -Append
-  Exit
-}
-
-
 ### Check validity of "what_ip" parameter
 if ( ($what_ip -ne "external") -and ($what_ip -ne "internal") ) {
   Write-Output 'Error! Incorrect "what_ip" parameter choose "external" or "internal"' | Tee-Object $File_LOG -Append
@@ -128,103 +115,127 @@ if ($proxied -eq $false) {
   $is_proxed = $proxied
 }
 
-### Get the dns record id and current proxy status from cloudflare's api when proxied is "true"
-if ($proxied -eq $true) {
-  $dns_record_info = @{
+foreach($current_key in $dns_records.Keys){
+	
+  # Set the variables for the current key
+  $a_record = $dns_records[$current_key]
+  $dns_record = $a_record['record']
+  $proxied = $a_record['proxied']
+  $ttl = $a_record['ttl']
+  
+  Write-Output "Checking $dns_record before processing..." | Tee-Object $File_LOG -Append
+
+  ### Check validity of "ttl" parameter
+  if (( $ttl -lt 60 ) -or ($ttl -gt 7200 ) -and ( $ttl -ne 1 )) {
+    Write-Output 'Error! ttl out of range (60) or not set to 1' | Tee-Object $File_LOG -Append
+    Continue
+  }
+
+  ### Check validity of "proxied" parameter
+  if (!([string]$proxied) -or ($proxied.GetType().Name.Trim() -ne "Boolean")) {
+    Write-Output 'Error! Incorrect "proxied" parameter choose "$true" or "$false" ' | Tee-Object $File_LOG -Append
+    Continue
+  }
+
+  Write-Output "Passed checks, processing $dns_record..." | Tee-Object $File_LOG -Append
+
+  ### Get the dns record id and current proxy status from cloudflare's api when proxied is "true"
+  if ($proxied -eq $true) {
+    $dns_record_info = @{
+      Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
+      Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
+    }
+
+    $response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @dns_record_info
+    if ($response.success -ne "True") {
+      Write-Output "Error! Can't get dns record info from cloudflare's api" | Tee-Object $File_LOG -Append
+    }
+    $is_proxed = $response.result.proxied
+    $dns_record_ip = $response.result.content.Trim()
+  }
+
+  ### Check if ip or proxy have changed
+  if (($dns_record_ip -eq $ip) -and ($is_proxed -eq $proxied)) {
+    Write-Output "==> DNS record IP of $dns_record is $dns_record_ip, no changes needed. Exiting..." | Tee-Object $File_LOG -Append
+    Continue
+  }
+
+  Write-Output "==> DNS record of $dns_record is: $dns_record_ip. Trying to update..." | Tee-Object $File_LOG -Append
+
+  ### Get the dns record information from cloudflare's api
+  $cloudflare_record_info = @{
     Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
     Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
   }
 
-  $response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @dns_record_info
-  if ($response.success -ne "True") {
-    Write-Output "Error! Can't get dns record info from cloudflare's api" | Tee-Object $File_LOG -Append
+  $cloudflare_record_info_resposne = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @cloudflare_record_info
+  if ($cloudflare_record_info_resposne.success -ne "True") {
+    Write-Output "Error! Can't get $dns_record record inforamiton from cloudflare API" | Tee-Object $File_LOG -Append
+    Continue
   }
-  $is_proxed = $response.result.proxied
-  $dns_record_ip = $response.result.content.Trim()
-}
+
+  ### Get the dns record id from response
+  $dns_record_id = $cloudflare_record_info_resposne.result.id.Trim()
+
+  ### Push new dns record information to cloudflare's api
+  $update_dns_record = @{
+    Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records/$dns_record_id"
+    Method  = 'PUT'
+    Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
+    Body    = @{
+      "type"    = switch ($IPv6) {
+          $true { "AAAA" }
+          $false { "A" }
+      }
+      "name"    = $dns_record
+      "content" = $ip
+      "ttl"     = $ttl
+      "proxied" = $proxied
+    } | ConvertTo-Json
+  }
+
+  $update_dns_record_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @update_dns_record
+  if ($update_dns_record_response.success -ne "True") {
+    Write-Output "Error! Update Failed" | Tee-Object $File_LOG -Append
+    Continue
+  }
+
+  Write-Output "==> Success!" | Tee-Object $File_LOG -Append
+  Write-Output "==> $dns_record DNS Record Updated To: $ip, ttl: $ttl, proxied: $proxied" | Tee-Object $File_LOG -Append
 
 
-### Check if ip or proxy have changed
-if (($dns_record_ip -eq $ip) -and ($is_proxed -eq $proxied)) {
-  Write-Output "==> DNS record IP of $dns_record is $dns_record_ip, no changes needed. Exiting..." | Tee-Object $File_LOG -Append
-  Exit
-}
+  if ($notify_me_telegram -eq "no" -And $notify_me_discord -eq "no")   {
+    Continue
+  }
 
-Write-Output "==> DNS record of $dns_record is: $dns_record_ip. Trying to update..." | Tee-Object $File_LOG -Append
-
-### Get the dns record information from cloudflare's api
-$cloudflare_record_info = @{
-  Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
-  Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
-}
-
-$cloudflare_record_info_resposne = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @cloudflare_record_info
-if ($cloudflare_record_info_resposne.success -ne "True") {
-  Write-Output "Error! Can't get $dns_record record inforamiton from cloudflare API" | Tee-Object $File_LOG -Append
-  Exit
-}
-
-### Get the dns record id from response
-$dns_record_id = $cloudflare_record_info_resposne.result.id.Trim()
-
-### Push new dns record information to cloudflare's api
-$update_dns_record = @{
-  Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records/$dns_record_id"
-  Method  = 'PUT'
-  Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
-  Body    = @{
-    "type"    = switch ($IPv6) {
-        $true { "AAAA" }
-        $false { "A" }
+  if ($notify_me_telegram -eq "yes") {
+    $telegram_notification = @{
+      Uri    = "https://api.telegram.org/bot$telegram_bot_API_Token/sendMessage?chat_id=$telegram_chat_id&text=$dns_record DNS Record Updated To: $ip"
+      Method = 'GET'
     }
-    "name"    = $dns_record
-    "content" = $ip
-    "ttl"     = $ttl
-    "proxied" = $proxied
-  } | ConvertTo-Json
-}
-
-$update_dns_record_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @update_dns_record
-if ($update_dns_record_response.success -ne "True") {
-  Write-Output "Error! Update Failed" | Tee-Object $File_LOG -Append
-  Exit
-}
-
-Write-Output "==> Success!" | Tee-Object $File_LOG -Append
-Write-Output "==> $dns_record DNS Record Updated To: $ip, ttl: $ttl, proxied: $proxied" | Tee-Object $File_LOG -Append
-
-
-if ($notify_me_telegram -eq "no" -And $notify_me_discord -eq "no")   {
-  Exit
-}
-
-if ($notify_me_telegram -eq "yes") {
-  $telegram_notification = @{
-    Uri    = "https://api.telegram.org/bot$telegram_bot_API_Token/sendMessage?chat_id=$telegram_chat_id&text=$dns_record DNS Record Updated To: $ip"
-    Method = 'GET'
-  }
-  $telegram_notification_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @telegram_notification
-  if ($telegram_notification_response.ok -ne "True") {
-    Write-Output "Error! Telegram notification failed" | Tee-Object $File_LOG -Append
-    Exit
-  }
-}
-
-if ($notify_me_discord -eq "yes") {
-  $discord_message = "$dns_record DNS Record Updated To: $ip (was $dns_record_ip)"
-  $discord_payload = [PSCustomObject]@{content = $discord_message} | ConvertTo-Json
-  $discord_notification = @{
-    Uri    = $discord_webhook_URL
-    Method = 'POST'
-    Body = $discord_payload
-    Headers = @{ "Content-Type" = "application/json" }
-  }
-    try {
-      Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @discord_notification
-    } catch {
-      Write-Host "==> Discord notification request failed. Here are the details for the exception:" | Tee-Object $File_LOG -Append
-      Write-Host "==> Request StatusCode:" $_.Exception.Response.StatusCode.value__  | Tee-Object $File_LOG -Append
-      Write-Host "==> Request StatusDescription:" $_.Exception.Response.StatusDescription | Tee-Object $File_LOG -Append
+    $telegram_notification_response = Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @telegram_notification
+    if ($telegram_notification_response.ok -ne "True") {
+      Write-Output "Error! Telegram notification failed" | Tee-Object $File_LOG -Append
+      Continue
     }
-    Exit
+  }
+
+  if ($notify_me_discord -eq "yes") {
+    $discord_message = "$dns_record DNS Record Updated To: $ip (was $dns_record_ip)"
+    $discord_payload = [PSCustomObject]@{content = $discord_message} | ConvertTo-Json
+    $discord_notification = @{
+      Uri    = $discord_webhook_URL
+      Method = 'POST'
+      Body = $discord_payload
+      Headers = @{ "Content-Type" = "application/json" }
+    }
+      try {
+        Invoke-RestMethod -Proxy $http_proxy -ProxyCredential $proxy_credential @discord_notification
+      } catch {
+        Write-Host "==> Discord notification request failed. Here are the details for the exception:" | Tee-Object $File_LOG -Append
+        Write-Host "==> Request StatusCode:" $_.Exception.Response.StatusCode.value__  | Tee-Object $File_LOG -Append
+        Write-Host "==> Request StatusDescription:" $_.Exception.Response.StatusDescription | Tee-Object $File_LOG -Append
+      }
+      Continue
+  }
 }

--- a/update-cloudflare-dns_conf.ps1
+++ b/update-cloudflare-dns_conf.ps1
@@ -3,8 +3,21 @@
 ## Which IP should be used for the record: internal/external
 ## Internal interface will be chosen automaticly as a primary default interface
 $what_ip = "internal"
-## DNS A record to be updated
-$dns_record = "ddns.example.com"
+## DNS A record or records to be updated
+## Each record is required to have the record to update, its proxied status, and cache time (60-7200 in seconds or 1 for Auto)
+$dns_records = [ordered]@{
+	record1 = @{
+		record = "ddns.example.com";
+		proxied = $true;
+		ttl = 1;
+	} #record 1 
+	record2 = @{
+			record = "ddns2.example.com";
+			proxied = $false; 
+			ttl = 1;
+	} #record 2
+}
+	
 ## Use IPv6
 $IPv6 = $false
 ## if use DoH to query the current IP address
@@ -13,10 +26,6 @@ $DNS_over_HTTPS = $false
 $zoneid = "ChangeMe"
 ## Cloudflare Zone API Token
 $cloudflare_zone_api_token = "ChangeMe"
-## Use Cloudflare proxy on dns record true/false
-$proxied = $false
-## 60-7200 in seconds or 1 for Auto
-$ttl = 120
 
 ## Use proxy when connect to DoH, Cloudflare, Telegram or Discord API
 # $http_proxy = $null


### PR DESCRIPTION
Small update to allow multiple records to be update using hash tables of hash tables (dictionary of dictionary). I have a few services that don't like CNAME entries on CloudFlare that need A/AAAA records, so I thought to contribute back this use case.

Adam Brousseau