### PR TITLE
Update update-cloudflare-dns.ps1

### DIFF
--- a/update-cloudflare-dns.ps1
+++ b/update-cloudflare-dns.ps1
@@ -154,7 +154,7 @@ Write-Output "==> DNS record of $dns_record is: $dns_record_ip. Trying to update
 
 ### Get the dns record information from cloudflare's api
 $cloudflare_record_info = @{
-  Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
+  Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record&type=$type"
   Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
 }
 


### PR DESCRIPTION
用于区分双栈域名
![image](https://github.com/fire1ce/DDNS-Cloudflare-PowerShell/assets/26104114/12cb96ac-7e88-4777-8946-4e99d25b2095)
当存在A与AAAA解析时原代码会返回两条值，导致出错
![image](https://github.com/fire1ce/DDNS-Cloudflare-PowerShell/assets/26104114/7cda74ec-cf8c-4759-9e9d-0a1565c0030e)
